### PR TITLE
Moved react native from dependency list to peer dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "dependencies": {
     "react-google-maps": "^8.5.0",
-    "react-native": "^0.51.0",
     "react-native-maps": "^0.19.0",
     "@types/react": "^16.0.9",
     "@types/react-dom": "^16.0.3"
   },
   "peerDependencies": {
     "react-dom": "16.2.0",
+    "react-native": "^0.51.0",
     "reactxp": "^0.51.1",
     "react": "16.2.0"
   },


### PR DESCRIPTION
The reason for this change is because with the current configuration, projects that include reactxp-maps in their project and also have react-native already installed will encounter building error when running react native because of duplicate modules. See also reactxp-video and reactxp-imagesvg as examples with the same solution.